### PR TITLE
Run vsgXchange CMake consumer test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: f9a58de8705ebdc0168d709cdd084efc069ff0caa4940a4edfe66dd6ba5bb076
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('vsgxchange', max_pin='x.x') }}
 
@@ -30,12 +30,15 @@ requirements:
     - libvulkan-headers
     - libvulkan-loader
     - openexr
-    - osg2vsg
+    # build 0 was linked against the older VulkanSceneGraph ABI.
+    - osg2vsg >=0.3.0 *_1
     - vulkanscenegraph >=1.1.15
   run:
     # GDAL 3.12+ has namespace GDAL that conflicts with vsgXchange class GDAL
     - libgdal-core
     - libvulkan-loader
+    # keep runtime resolution away from osg2vsg build 0's old VSG ABI.
+    - osg2vsg >=0.3.0 *_1
     - vulkanscenegraph
 
 test:

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -8,3 +8,6 @@ if errorlevel 1 exit 1
 
 cmake --build tests/build --parallel --config Release
 if errorlevel 1 exit 1
+
+ctest --test-dir tests/build --output-on-failure -C Release
+if errorlevel 1 exit 1

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -10,3 +10,4 @@ cmake tests \
     -DCMAKE_BUILD_TYPE=Release
 
 cmake --build tests/build --parallel
+ctest --test-dir tests/build --output-on-failure

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -10,4 +10,6 @@ cmake tests \
     -DCMAKE_BUILD_TYPE=Release
 
 cmake --build tests/build --parallel
+export LD_LIBRARY_PATH="${PREFIX}/lib:${LD_LIBRARY_PATH:-}"
+export DYLD_FALLBACK_LIBRARY_PATH="${PREFIX}/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
 ctest --test-dir tests/build --output-on-failure

--- a/recipe/tests/CMakeLists.txt
+++ b/recipe/tests/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.7)
 
 project(vsghelloworld)
 
+include(CTest)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -11,3 +13,4 @@ find_package(vsgXchange CONFIG REQUIRED)
 
 add_executable(vsghelloworld main.cpp)
 target_link_libraries(vsghelloworld PRIVATE vsg::vsg vsgXchange::vsgXchange)
+add_test(NAME vsgxchange_consumer COMMAND vsghelloworld)


### PR DESCRIPTION
This follow-up makes the downstream CMake consumer test execute, not just compile, and rebuilds `vsgxchange` against the rebuilt `osg2vsg` package.

Changes:
- Register the existing `find_package(vsg CONFIG REQUIRED)` / `find_package(vsgXchange CONFIG REQUIRED)` consumer executable with CTest.
- Run CTest from Unix and Windows package-test scripts.
- Export the prefix library path before Unix CTest so the just-built consumer can load shared libraries from the test environment.
- Bump the build number to 1 and require `osg2vsg >=0.3.0 *_1` in host/run so the rebuild and runtime metadata avoid `osg2vsg` build 0, which is linked against the older VulkanSceneGraph ABI.

Validation:
- `git diff --check upstream/main..HEAD`
- `conda-smithy recipe-lint --conda-forge recipe`

Current note: the first run on this metadata failed before build because live repodata had not yet picked up the already-uploaded `osg2vsg` build 1 artifacts. I will rerun after repodata propagation.